### PR TITLE
tldr: Use `main` branch instead of `master`

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	RemoteBaseURL = "https://raw.githubusercontent.com/tldr-pages/tldr/master"
+	RemoteBaseURL = "https://raw.githubusercontent.com/tldr-pages/tldr/main"
 )
 
 func buildRemotePath(cfg *Config, platform string) string {


### PR DESCRIPTION
[About 1.5 years ago](https://github.com/tldr-pages/tldr/discussions/5868), we deprecated the master branch in favour of the main branch. We intend to remove it [soon, likely by May 1st 2023](https://github.com/tldr-pages/tldr/issues/9628).